### PR TITLE
add long

### DIFF
--- a/data_generator/data_generator.py
+++ b/data_generator/data_generator.py
@@ -56,7 +56,7 @@ class MetaFaker:
         elif col.get("enum"):
             return self.fake_enum(col.get("enum"))
 
-        elif col["type"] == "int":
+        elif col["type"] in ["int", "long"]:
             return self.fake_int(col)
 
         elif col["type"] in ["double", "float"]:


### PR DESCRIPTION
fixes #4 - turns out `random_int` doesn't seem to be limited in the size of numbers so can be used as well